### PR TITLE
Remove TestDino Reporter upload step from CI pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,10 +36,6 @@ jobs:
           echo "Current path: $(pwd)"
           ls -R ./playwright-report
 
-      - name: TestDino Reporter
-        run: 
-         npx tdpw upload ./playwright-report --token="trx_production_8dbb7e2e38a1b0caf5db44fce5928b12de07bb7b3d3def41425afa8c8609430e"
-
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Removed the TestDino Reporter upload step from the GitHub Actions CI pipeline.

## Changes
- Removed the "TestDino Reporter" job step that was uploading playwright test reports to TestDino using the `tdpw upload` command
- This step was located in the pipeline workflow between the report listing step and the artifact upload step

## Details
The TestDino Reporter integration has been removed from the automated CI/CD pipeline. Test reports will no longer be automatically uploaded to TestDino during pipeline execution. The standard artifact upload step remains in place for storing test results.

https://claude.ai/code/session_01Vks6P1cYVRqY4wMsdxpavC