### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, homolog]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brav999/landingpage-aine/security/code-scanning/1](https://github.com/brav999/landingpage-aine/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/pipeline.yml` so the workflow does not rely on repository/org defaults.  
Best approach here: define permissions at the workflow root (applies to all jobs unless overridden), with the minimal required scope. For this pipeline, `contents: read` is the recommended baseline and is sufficient for checkout/build/test/artifact upload in this configuration.

Edit region:
- File: `.github/workflows/pipeline.yml`
- Insert `permissions:` after the `on:` section (before `jobs:`), with:
  - `contents: read`

No imports, methods, or additional definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
